### PR TITLE
fix: use import_tasks for upgrade tasks to inherit tags

### DIFF
--- a/DAG.md
+++ b/DAG.md
@@ -3,6 +3,7 @@ graph TD
 
     claude -->|depends on| facts
     facts
+    gh-extensions -->|depends on| misc-packages
     git -->|depends on| facts
     git -->|depends on| omz-zshrc
     misc-dotfiles -->|depends on| facts

--- a/main.yml
+++ b/main.yml
@@ -3,6 +3,7 @@
   roles:
     - role: git
     - role: misc-packages
+    - role: gh-extensions
     - role: omz-zshrc
       when: ansible_facts["os_family"] == "Darwin"
     - role: misc-dotfiles

--- a/roles/claude/vars/main.yml
+++ b/roles/claude/vars/main.yml
@@ -9,8 +9,8 @@ claude_settings:
       - "Bash(cat:*)"
       - "Bash(find:*)"
       # Super cool cheatcodes. 
-      "Bash(* --version)",
-      "Bash(* --help *)"
+      - "Bash(* --version)"
+      - "Bash(* --help *)"
       # Gcloud
       - "Bash(gcloud run services describe:*)"
       - "Bash(gcloud logging read:*)"

--- a/roles/gh-extensions/meta/main.yml
+++ b/roles/gh-extensions/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: misc-packages

--- a/roles/gh-extensions/tasks/install.yml
+++ b/roles/gh-extensions/tasks/install.yml
@@ -1,0 +1,10 @@
+---
+- name: Get list of installed GitHub CLI extensions
+  ansible.builtin.command: gh extension list
+  register: gh_ext_list_result
+  changed_when: false
+
+- name: Install GitHub CLI extensions
+  ansible.builtin.command: gh extension install {{ item }}
+  loop: "{{ gh_extensions }}"
+  when: item not in gh_ext_list_result.stdout

--- a/roles/gh-extensions/tasks/main.yml
+++ b/roles/gh-extensions/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# tasks file for gh-extensions
+
+- name: Install GitHub CLI extensions
+  ansible.builtin.import_tasks: install.yml
+
+- name: Upgrade GitHub CLI extensions
+  ansible.builtin.import_tasks: upgrade.yml
+  tags: [upgrade, never]

--- a/roles/gh-extensions/tasks/upgrade.yml
+++ b/roles/gh-extensions/tasks/upgrade.yml
@@ -1,0 +1,5 @@
+---
+- name: Upgrade GitHub CLI extensions
+  ansible.builtin.command: gh extension upgrade {{ item }}
+  loop: "{{ gh_extensions }}"
+  changed_when: true

--- a/roles/gh-extensions/vars/main.yml
+++ b/roles/gh-extensions/vars/main.yml
@@ -1,0 +1,5 @@
+---
+# vars file for gh-extensions
+gh_extensions:
+  - karldreher/gh-qpr
+  - karldreher/gh-tag

--- a/roles/misc-packages/tasks/main.yml
+++ b/roles/misc-packages/tasks/main.yml
@@ -18,11 +18,11 @@
   when: ansible_facts["os_family"] == "Debian"
 
 - name: Upgrade macOS homebrew packages
-  ansible.builtin.include_tasks: brew_upgrade.yml
+  ansible.builtin.import_tasks: brew_upgrade.yml
   when: ansible_facts["os_family"] == "Darwin"
   tags: [upgrade, never]
 
 - name: Upgrade linux apt packages
-  ansible.builtin.include_tasks: apt_upgrade.yml
+  ansible.builtin.import_tasks: apt_upgrade.yml
   when: ansible_facts["os_family"] == "Debian"
   tags: [upgrade, never]


### PR DESCRIPTION
## Summary

- Fixed upgrade task tag inheritance by switching from dynamic `include_tasks` to static `import_tasks` in misc-packages role
- Tags on `import_tasks` directives are properly inherited by all sub-tasks, ensuring `--tags upgrade` filter works correctly
- Added new `gh-extensions` role to manage GitHub CLI extensions (`gh extension install` and `gh extension upgrade`)
  - Declares dependency on misc-packages (which provides `gh` CLI)
  - Install tasks idempotently check `gh extension list` before installing
  - Upgrade tasks run only when `--tags upgrade` is specified

## Test plan

- [ ] Run `ansible-playbook main.yml --tags upgrade --extra-vars "email=... firstname=... lastname=..."`
- [ ] Verify `Update homebrew` and upgrade tasks from misc-packages execute (changed=1+)
- [ ] Verify `Upgrade GitHub CLI extensions` task executes for gh-extensions
- [ ] Run without `--tags upgrade` and verify extensions are installed via `Install GitHub CLI extensions` task
- [ ] Check `gh extension list` includes gh-qpr and gh-tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)