### PR TITLE
feat: add alacritty config to misc-dotfiles (debian only)

### DIFF
--- a/roles/misc-dotfiles/tasks/alacritty.yml
+++ b/roles/misc-dotfiles/tasks/alacritty.yml
@@ -1,0 +1,11 @@
+---
+- name: Create alacritty config directory
+  ansible.builtin.file:
+    path: "{{ homedir.stdout }}/.config/alacritty"
+    state: directory
+
+- name: Template alacritty config to $HOME/.config/alacritty/alacritty.toml
+  ansible.builtin.template:
+    src: templates/alacritty/alacritty.toml.j2
+    dest: "{{ homedir.stdout }}/.config/alacritty/alacritty.toml"
+    mode: "0644"

--- a/roles/misc-dotfiles/tasks/main.yml
+++ b/roles/misc-dotfiles/tasks/main.yml
@@ -21,3 +21,7 @@
     src: templates/ghostty/config.j2
     dest: "{{ homedir.stdout }}/.config/ghostty/config"
     mode: "0644"
+
+- name: Configure alacritty
+  ansible.builtin.include_tasks: alacritty.yml
+  when: ansible_facts["os_family"] == "Debian"

--- a/roles/misc-dotfiles/templates/alacritty/alacritty.toml.j2
+++ b/roles/misc-dotfiles/templates/alacritty/alacritty.toml.j2
@@ -1,0 +1,5 @@
+
+[[keyboard.bindings]]
+key = "Return"
+mods = "Shift"
+chars = "\u001B\r"


### PR DESCRIPTION
## Summary

- Added Alacritty terminal config management to the `misc-dotfiles` role
- Configuration deployed to `~/.config/alacritty/alacritty.toml` on Debian only
- Created separate task file (`alacritty.yml`) following repo convention from `misc-packages` role
- Includes keyboard binding for Shift+Enter

## Test plan

- [ ] Run `ansible-playbook main.yml --check --diff` on a Debian host to confirm tasks are picked up
- [ ] Verify `~/.config/alacritty/alacritty.toml` gets templated with correct binding
- [ ] Run on non-Debian host to confirm tasks are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)