### PR TITLE
feat: broaden gcloud allow list to cover all describe and list subcommands

### DIFF
--- a/roles/claude/vars/main.yml
+++ b/roles/claude/vars/main.yml
@@ -12,7 +12,8 @@ claude_settings:
       - "Bash(* --version)"
       - "Bash(* --help *)"
       # Gcloud
-      - "Bash(gcloud run services describe*)"
+      - "Bash(gcloud * describe*)"
+      - "Bash(gcloud * list*)"
       - "Bash(gcloud logging read*)"
       # GH cli, mostly read oriented.  
       - "Bash(gh issue list*)"


### PR DESCRIPTION
## Summary
- Replaces the narrow `gcloud run services describe*` entry with two broad wildcard patterns
- `Bash(gcloud * describe*)` and `Bash(gcloud * list*)` now cover all gcloud read-oriented subcommands without needing per-service entries

## Test plan
- [ ] Verify Claude no longer prompts for permission on `gcloud projects list`, `gcloud run services list`, etc.
- [ ] Verify describe commands (e.g. `gcloud compute instances describe`) are also auto-allowed