### PR TITLE
feat: add rtk install and init tasks to claude role

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,5 @@
+# ansible-playbooks
+
+## Linting
+
+Use `uvx ansible-lint` to run ansible-lint (no local install required).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(uvx ansible-lint*)"
+    ]
+  }
+}

--- a/roles/claude/tasks/config.yml
+++ b/roles/claude/tasks/config.yml
@@ -44,11 +44,6 @@
     dest: "{{ homedir.stdout }}/.claude/settings.json"
     mode: "0644"
 
-- name: Check if rtk hook is installed
-  ansible.builtin.stat:
-    path: "{{ homedir.stdout }}/.claude/hooks/.rtk-hook.sha256"
-  register: rtk_hook
-
 - name: Template CLAUDE.md
   ansible.builtin.template:
     src: templates/CLAUDE.md.j2

--- a/roles/claude/tasks/config.yml
+++ b/roles/claude/tasks/config.yml
@@ -44,6 +44,11 @@
     dest: "{{ homedir.stdout }}/.claude/settings.json"
     mode: "0644"
 
+- name: Check if rtk hook is installed
+  ansible.builtin.stat:
+    path: "{{ homedir.stdout }}/.claude/hooks/.rtk-hook.sha256"
+  register: rtk_hook
+
 - name: Template CLAUDE.md
   ansible.builtin.template:
     src: templates/CLAUDE.md.j2

--- a/roles/claude/tasks/main.yml
+++ b/roles/claude/tasks/main.yml
@@ -7,14 +7,14 @@
     state: directory
     mode: "0755"
 
-- name: Configure claude settings and CLAUDE.md
-  ansible.builtin.include_tasks: config.yml
-
-- name: Install claude skills
-  ansible.builtin.include_tasks: skills.yml
-
 - name: Install rtk
   ansible.builtin.include_tasks: rtk_install.yml
 
 - name: Initialize rtk globally
   ansible.builtin.include_tasks: rtk_init.yml
+
+- name: Configure claude settings and CLAUDE.md
+  ansible.builtin.include_tasks: config.yml
+
+- name: Install claude skills
+  ansible.builtin.include_tasks: skills.yml

--- a/roles/claude/tasks/main.yml
+++ b/roles/claude/tasks/main.yml
@@ -12,3 +12,9 @@
 
 - name: Install claude skills
   ansible.builtin.include_tasks: skills.yml
+
+- name: Install rtk
+  ansible.builtin.include_tasks: rtk_install.yml
+
+- name: Initialize rtk globally
+  ansible.builtin.include_tasks: rtk_init.yml

--- a/roles/claude/tasks/rtk_init.yml
+++ b/roles/claude/tasks/rtk_init.yml
@@ -7,5 +7,6 @@
 
 - name: Initialize rtk globally
   ansible.builtin.command: rtk init -g
-  when: which_claude.rc == 0
-  changed_when: false
+  when:
+    - which_claude.rc == 0
+    - not rtk_hook.stat.exists

--- a/roles/claude/tasks/rtk_init.yml
+++ b/roles/claude/tasks/rtk_init.yml
@@ -5,6 +5,11 @@
   failed_when: false
   changed_when: false
 
+- name: Check if rtk hook is installed
+  ansible.builtin.stat:
+    path: "{{ homedir.stdout }}/.claude/hooks/.rtk-hook.sha256"
+  register: rtk_hook
+
 - name: Initialize rtk globally
   ansible.builtin.command: rtk init -g
   when:

--- a/roles/claude/tasks/rtk_init.yml
+++ b/roles/claude/tasks/rtk_init.yml
@@ -1,0 +1,11 @@
+---
+- name: Check if claude is installed
+  ansible.builtin.command: which claude
+  register: which_claude
+  failed_when: false
+  changed_when: false
+
+- name: Initialize rtk globally
+  ansible.builtin.command: rtk init -g
+  when: which_claude.rc == 0
+  changed_when: false

--- a/roles/claude/tasks/rtk_install.yml
+++ b/roles/claude/tasks/rtk_install.yml
@@ -1,0 +1,14 @@
+---
+- name: Install rtk via Homebrew
+  community.general.homebrew:
+    name: rtk
+    state: present
+  when: ansible_facts["os_family"] == "Darwin"
+
+- name: Install rtk via install script
+  ansible.builtin.shell: |
+    curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+  args:
+    creates: "{{ homedir.stdout }}/.local/bin/rtk"
+  when: ansible_facts["os_family"] == "Debian"
+  register: rtk_install

--- a/roles/claude/templates/CLAUDE.md.j2
+++ b/roles/claude/templates/CLAUDE.md.j2
@@ -63,3 +63,7 @@ Follow blameless postmortem principles (reference: https://sre.google/sre-book/p
 - Assume good intentions, but focus on systemic causes — frame as "the system allowed X" rather than "Person X caused Y"
 - Be direct and analytical — state what went wrong plainly without softening findings or hedging excessively
 - Fair does not mean gentle: identify gaps honestly, just attribute them to processes and systems rather than character
+{% if rtk_hook.stat.exists %}
+
+@RTK.md
+{% endif %}


### PR DESCRIPTION
## Summary
- Adds platform-specific RTK installation to the `claude` role: Homebrew on macOS, curl script on Linux, both in a single `rtk_install.yml` with per-task `when:` conditions
- Adds `rtk_init.yml` which checks if `claude` is on PATH and runs `rtk init -g` if so
