### PR TITLE
chore: remove raycast from macos brew casks

### DIFF
--- a/roles/misc_packages/tasks/brew_remove.yml
+++ b/roles/misc_packages/tasks/brew_remove.yml
@@ -1,0 +1,5 @@
+---
+- name: Remove misc MacOS casks
+  community.general.homebrew_cask:
+    name: "{{ misc_packages_macos_brew_remove_casks }}"
+    state: absent

--- a/roles/misc_packages/tasks/main.yml
+++ b/roles/misc_packages/tasks/main.yml
@@ -5,6 +5,10 @@
   ansible.builtin.include_tasks: brew_packages.yml
   when: ansible_facts["os_family"] == "Darwin"
 
+- name: Remove macos homebrew packages
+  ansible.builtin.include_tasks: brew_remove.yml
+  when: ansible_facts["os_family"] == "Darwin"
+
 
 - name: Install script-based packages
   ansible.builtin.include_tasks: script-packages.yml

--- a/roles/misc_packages/vars/main.yml
+++ b/roles/misc_packages/vars/main.yml
@@ -29,5 +29,4 @@ misc_packages_macos_brew_packages:
 
 misc_packages_macos_brew_casks:
   - ghostty
-  - raycast
   - rectangle

--- a/roles/misc_packages/vars/main.yml
+++ b/roles/misc_packages/vars/main.yml
@@ -30,3 +30,6 @@ misc_packages_macos_brew_packages:
 misc_packages_macos_brew_casks:
   - ghostty
   - rectangle
+
+misc_packages_macos_brew_remove_casks:
+  - raycast


### PR DESCRIPTION
## Summary
- Removes Raycast from the `misc_packages_macos_brew_casks` list in the `misc_packages` role

## Test plan
- [ ] Run the playbook on a macOS host and confirm Raycast is not installed