### PR TITLE
feat: add rbenv package and conditional zsh init

### DIFF
--- a/roles/misc_packages/vars/main.yml
+++ b/roles/misc_packages/vars/main.yml
@@ -20,6 +20,7 @@ misc_packages_macos_brew_packages:
   - kubectx
   - parallel
   - pyenv
+  - rbenv
   - rsync
   - tmux
   - tree

--- a/roles/omz_zshrc/tasks/main.yml
+++ b/roles/omz_zshrc/tasks/main.yml
@@ -11,6 +11,11 @@
     path: "{{ homedir.stdout }}/.goenv"
   register: omz_zshrc_goenv_folder
 
+- name: Check that rbenv folder exists
+  ansible.builtin.stat:
+    path: "{{ homedir.stdout }}/.rbenv"
+  register: omz_zshrc_rbenv_folder
+
 - name: Tfswitch enabled
   # TODO: Refactor this more elegantly later, but this is more of a
   # matter of placement.  Syntactically it is correct.
@@ -56,6 +61,13 @@
     dest: "{{ homedir.stdout }}/.oh-my-zsh/custom/zsh-goenv.zsh"
     mode: "0644"
   when: "omz_zshrc_goenv_folder.stat.exists and omz_zshrc_goenv_folder.stat.isdir"
+
+- name: Template rbenv
+  ansible.builtin.template:
+    src: zsh-custom/zsh-rbenv.zsh.j2
+    dest: "{{ homedir.stdout }}/.oh-my-zsh/custom/zsh-rbenv.zsh"
+    mode: "0644"
+  when: "omz_zshrc_rbenv_folder.stat.exists and omz_zshrc_rbenv_folder.stat.isdir"
 
 - name: Template git_acp.zsh
   ansible.builtin.template:

--- a/roles/omz_zshrc/templates/zsh-custom/zsh-rbenv.zsh.j2
+++ b/roles/omz_zshrc/templates/zsh-custom/zsh-rbenv.zsh.j2
@@ -1,0 +1,1 @@
+eval "$(rbenv init - zsh)"


### PR DESCRIPTION
## Summary
- Adds `rbenv` to macOS Homebrew packages in `misc_packages`
- Follows the goenv conditional pattern: stat-checks `~/.rbenv` and deploys `zsh-rbenv.zsh.j2` only when the directory exists
- New template runs `eval "$(rbenv init - zsh)"` for zsh shell integration

## Test plan
- [ ] Run playbook on macOS with rbenv installed — confirm `~/.oh-my-zsh/custom/zsh-rbenv.zsh` is deployed
- [ ] Confirm `rbenv` is available in new shell session after playbook run
- [ ] Run `uvx ansible-lint` — no violations