### PR TITLE
fix: run bunx skill steps and rtk upgrade on linux

### DIFF
--- a/roles/claude/tasks/marketplace_skills.yml
+++ b/roles/claude/tasks/marketplace_skills.yml
@@ -6,7 +6,6 @@
   loop: "{{ claude_marketplace_skills }}"
   loop_control:
     label: "{{ item.skill }}"
-  when: ansible_facts["os_family"] == "Darwin"
 
 - name: Remove marketplace skills
   ansible.builtin.command: bunx skills remove -g {{ item.repo }} --skill {{ item.skill }} --yes
@@ -15,4 +14,3 @@
   loop: "{{ claude_marketplace_skills_remove }}"
   loop_control:
     label: "{{ item.skill }}"
-  when: ansible_facts["os_family"] == "Darwin"

--- a/roles/claude/tasks/rtk_upgrade.yml
+++ b/roles/claude/tasks/rtk_upgrade.yml
@@ -5,6 +5,15 @@
     state: latest
   when: ansible_facts["os_family"] == "Darwin"
 
+- name: Upgrade rtk via install script  # noqa: command-instead-of-module
+  ansible.builtin.shell: |
+    set -o pipefail
+    curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+  args:
+    executable: /bin/bash
+  changed_when: true
+  when: ansible_facts["os_family"] == "Debian"
+
 - name: Refresh rtk global configuration
   ansible.builtin.command: rtk init -g --auto-patch
   changed_when: true


### PR DESCRIPTION
## Summary
- Remove the `os_family == "Darwin"` guard from the marketplace-skill install/remove tasks so `bunx skills add/remove` runs on Linux (bunx is installed cross-platform by `misc_packages`); the `creates:`/`removes:` guards keep them idempotent
- Add a Debian-branch "Upgrade rtk via install script" task to `rtk_upgrade.yml`, giving Linux a real rtk upgrade path (the install-script task in `rtk_install.yml` is `creates:`-guarded and never upgrades); mirrors the OS split in `rtk_install.yml` and inherits the `upgrade`/`never` tags

## Test plan
- [x] `uvx ansible-lint roles/claude/` passes clean (16 files)
- [ ] `ansible-playbook main.yml --tags claude --check` on Linux shows the "Install marketplace skills" task is no longer skipped