### PR TITLE
feat: add antigravity role for agy CLI integration

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -9,3 +9,5 @@
       when: ansible_facts["os_family"] == "Darwin"
     - role: misc_dotfiles
     - role: claude
+    - role: antigravity
+      when: which_agy.rc == 0

--- a/roles/antigravity/defaults/main.yml
+++ b/roles/antigravity/defaults/main.yml
@@ -1,0 +1,1 @@
+# defaults file for antigravity

--- a/roles/antigravity/meta/main.yml
+++ b/roles/antigravity/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: facts

--- a/roles/antigravity/tasks/main.yml
+++ b/roles/antigravity/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+# tasks file for antigravity
+# Role is only included from main.yml when which_agy.rc == 0 (see roles/facts).
+
+# TODO: once rtk ships a global (non-cwd-hardcoded) Antigravity integration, wire up
+# rtk install + GEMINI.md RTK guidance here, mirroring roles/claude's rtk_init.yml.
+
+- name: Create .gemini/antigravity-cli directory
+  ansible.builtin.file:
+    path: "{{ homedir.stdout }}/.gemini/antigravity-cli"
+    state: directory
+    mode: "0755"
+
+- name: Check if settings.json exists
+  ansible.builtin.stat:
+    path: "{{ homedir.stdout }}/.gemini/antigravity-cli/settings.json"
+  register: antigravity_settings_file
+
+- name: Read existing settings.json
+  ansible.builtin.slurp:
+    src: "{{ homedir.stdout }}/.gemini/antigravity-cli/settings.json"
+  register: antigravity_existing_settings_raw
+  when: antigravity_settings_file.stat.exists
+
+- name: Parse existing settings
+  ansible.builtin.set_fact:
+    antigravity_existing_settings: "{{ antigravity_existing_settings_raw.content | b64decode | from_json }}"
+  when: antigravity_settings_file.stat.exists
+
+- name: Set empty settings when file does not exist
+  ansible.builtin.set_fact:
+    antigravity_existing_settings: {}
+  when: not antigravity_settings_file.stat.exists
+
+- name: Build merged settings
+  ansible.builtin.set_fact:
+    antigravity_merged_settings: >-
+      {{
+        antigravity_existing_settings
+        | combine(antigravity_settings, recursive=true)
+        | combine({
+            'permissions': {
+              'allow': (
+                (antigravity_existing_settings.permissions.allow | default([]))
+                + antigravity_settings.permissions.allow
+              ) | unique,
+              'deny': (
+                (antigravity_existing_settings.permissions.deny | default([]))
+                + antigravity_settings.permissions.deny
+              ) | unique
+            }
+          }, recursive=true)
+      }}
+
+- name: Write merged settings.json
+  ansible.builtin.copy:
+    content: "{{ antigravity_merged_settings | to_nice_json }}\n"
+    dest: "{{ homedir.stdout }}/.gemini/antigravity-cli/settings.json"
+    mode: "0644"
+
+- name: Template GEMINI.md
+  ansible.builtin.template:
+    src: templates/GEMINI.md.j2
+    dest: "{{ homedir.stdout }}/.gemini/GEMINI.md"
+    mode: "0644"

--- a/roles/antigravity/templates/GEMINI.md.j2
+++ b/roles/antigravity/templates/GEMINI.md.j2
@@ -1,0 +1,7 @@
+## System
+
+{% if ansible_facts["os_family"] == "Darwin" %}
+This system is a MacOS device. Use `brew` for package management. Prefer `pbcopy`/`pbpaste` for clipboard. Use `open` to open files/URLs.
+{% elif ansible_facts["os_family"] == "Debian" %}
+This system is a Linux Debian system. Use `apt` for package management. Use `xdg-open` to open files/URLs.
+{% endif %}

--- a/roles/antigravity/vars/main.yml
+++ b/roles/antigravity/vars/main.yml
@@ -1,0 +1,19 @@
+# Reference (best-effort, no fetchable primary doc page as of writing):
+# https://antigravity.google/docs/cli-permissions
+# Global settings live at ~/.gemini/antigravity-cli/settings.json
+
+antigravity_settings:
+  toolPermission: "request-review" # verify key name against real settings.json
+  permissions:
+    # Always allow these tools, and never ask for permission to use them.
+    # Add entries in alphabetical order for readability.
+    allow:
+      - "command(cat)"
+      - "command(find)"
+      - "command(gh pr list)"
+      - "command(gh pr view)"
+      - "command(git diff)"
+      - "command(git log)"
+      - "command(git status)"
+    deny:
+      - "command(rm -rf)"

--- a/roles/facts/tasks/main.yml
+++ b/roles/facts/tasks/main.yml
@@ -4,6 +4,12 @@
   register: homedir # noqa: var-naming[no-role-prefix]
   changed_when: false
 
+- name: Check if agy (Antigravity CLI) is installed
+  ansible.builtin.command: which agy
+  register: which_agy # noqa: var-naming[no-role-prefix]
+  failed_when: false
+  changed_when: false
+
 - name: "Check mandatory variables are defined"
   ansible.builtin.assert:
     that:


### PR DESCRIPTION
## Summary
- Add new antigravity role for integrating Antigravity CLI (agy)
- Check if agy CLI is installed using facts role
- Conditionally include antigravity role only when CLI is available

## Test plan
- [ ] Run ansible-lint to verify no violations
- [ ] Test on system with agy CLI installed
- [ ] Test on system without agy CLI to verify conditional skip

https://claude.ai/code/session_01WjDiL4hEXic6SgMKye9UfM