### PR TITLE
feat: disable claude code auto-memory by default

### DIFF
--- a/roles/claude/vars/main.yml
+++ b/roles/claude/vars/main.yml
@@ -19,6 +19,7 @@ claude_settings:
   attribution:
     commit: ""
     pr: ""
+  autoMemoryEnabled: false
   permissions:
     # Always allow these tools, and never ask for permission to use them.
     # Add entries in alphabetical order for readability.  Maintain the sections.


### PR DESCRIPTION
## Summary
- Adds `autoMemoryEnabled: false` to `claude_settings` in `roles/claude/vars/main.yml`, disabling Claude Code's auto-memory feature by default on managed machines.
- This is deep-merged into each host's `~/.claude/settings.json` by the existing playbook logic in `roles/claude/tasks/config.yml`; no template or task changes were needed.

## Test plan
- [x] `uvx ansible-lint` passes with 0 failures/warnings