### PR TITLE
feat: add zsh history dedup and filtering options

### DIFF
--- a/roles/omz_zshrc/templates/zshrc.zsh.j2
+++ b/roles/omz_zshrc/templates/zshrc.zsh.j2
@@ -34,6 +34,24 @@ FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
 
 source $ZSH/oh-my-zsh.sh
 
+{# History options: https://zsh.sourceforge.io/Doc/Release/Options.html#History #}
+{# Placed after sourcing omz to override its lib/history.zsh defaults. #}
+
+{# https://zsh.sourceforge.io/Doc/Release/Options.html#index-HIST_005fIGNORE_005fALL_005fDUPS #}
+{# Supersedes omz's default HIST_IGNORE_DUPS (only catches consecutive dups). #}
+setopt hist_ignore_all_dups
+
+{# https://zsh.sourceforge.io/Doc/Release/Options.html#index-HIST_005fSAVE_005fNO_005fDUPS #}
+{# Safety net for dups merged in via omz's SHARE_HISTORY. #}
+setopt hist_save_no_dups
+
+{# https://zsh.sourceforge.io/Doc/Release/Options.html#index-HIST_005fIGNORE_005fSPACE #}
+{# Already an omz default; restated to pin it explicitly. #}
+setopt hist_ignore_space
+
+{# https://zsh.sourceforge.io/Doc/Release/Options.html#index-HIST_005fNO_005fFUNCTIONS #}
+setopt hist_no_functions
+
 export EDITOR=vim
 
 {% if misc_packages_bun_install|default(false) %}


### PR DESCRIPTION
## Summary
- Adds `setopt` lines for `HIST_IGNORE_ALL_DUPS`, `HIST_SAVE_NO_DUPS`, `HIST_IGNORE_SPACE`, and `HIST_NO_FUNCTIONS` to `roles/omz_zshrc/templates/zshrc.zsh.j2`, placed after sourcing oh-my-zsh so they take precedence over its `lib/history.zsh` defaults.
- Documents each option with Jinja `{# #}` comments linking to the relevant zsh docs section — these are stripped at render time so they don't appear in the generated `.zshrc`.
- `HIST_IGNORE_ALL_DUPS` is used in place of `HIST_IGNORE_DUPS` since it's a strict superset (catches non-consecutive duplicates too).

## Test plan
- [x] `uvx ansible-lint roles/omz_zshrc/templates/zshrc.zsh.j2` passes
- [x] Rendered template with sample vars to confirm placement, correct Jinja syntax, and that comments are stripped from output
- [x] Verified all four `setopt` names are recognized/active in a real zsh session