### PR TITLE
feat: deny mutating brew/apt commands via claude permissions

### DIFF
--- a/roles/claude/tasks/config.yml
+++ b/roles/claude/tasks/config.yml
@@ -33,6 +33,10 @@
               'allow': (
                 (claude_existing_settings.permissions.allow | default([]))
                 + claude_settings.permissions.allow
+              ) | unique,
+              'deny': (
+                (claude_existing_settings.permissions.deny | default([]))
+                + claude_settings.permissions.deny
               ) | unique
             }
           }, recursive=true)

--- a/roles/claude/templates/CLAUDE.md.j2
+++ b/roles/claude/templates/CLAUDE.md.j2
@@ -1,10 +1,14 @@
 ## System
 
 {% if ansible_facts["os_family"] == "Darwin" %}
-This system is a MacOS device. Use `brew` for package management. Prefer `pbcopy`/`pbpaste` for clipboard. Use `open` to open files/URLs.
+This system is a MacOS device. Prefer `pbcopy`/`pbpaste` for clipboard. Use `open` to open files/URLs.
 {% elif ansible_facts["os_family"] == "Debian" %}
-This system is a Linux Debian system. Use `apt` for package management. Use `xdg-open` to open files/URLs.
+This system is a Linux Debian system. Use `xdg-open` to open files/URLs.
 {% endif %}
+
+## Package Management
+
+- Read-only `brew`/`apt`/`apt-get` commands (e.g. `list`, `info`, `search`, `show`) are fine. Mutating subcommands — `install`, `remove`, `uninstall`, `upgrade`, `update`, and similar — are not allowed and are blocked by settings. This is an Ansible-managed environment; package changes belong in the relevant role (e.g. `roles/misc_packages`), not ad-hoc shell commands.
 
 
 ## Interaction

--- a/roles/claude/vars/main.yml
+++ b/roles/claude/vars/main.yml
@@ -29,6 +29,27 @@ claude_settings:
       # Super cool cheatcodes.
       - "Bash(* --version)"
       - "Bash(* --help *)"
+      # Apt (Linux), read-only subcommands only. Mutating subcommands (install,
+      # remove, upgrade, etc.) are denied below — package changes belong in
+      # roles/misc_packages, not ad-hoc commands.
+      - "Bash(apt list*)"
+      - "Bash(apt search*)"
+      - "Bash(apt show*)"
+      - "Bash(apt-cache policy*)"
+      - "Bash(apt-cache search*)"
+      - "Bash(apt-cache show*)"
+      # Homebrew (macOS), read-only subcommands only. Mutating subcommands (install,
+      # remove, upgrade, etc.) are denied below — package changes belong in
+      # roles/misc_packages, not ad-hoc commands.
+      - "Bash(brew config*)"
+      - "Bash(brew deps*)"
+      - "Bash(brew doctor*)"
+      - "Bash(brew info*)"
+      - "Bash(brew leaves*)"
+      - "Bash(brew list*)"
+      - "Bash(brew outdated*)"
+      - "Bash(brew search*)"
+      - "Bash(brew uses*)"
       # Gcloud
       - "Bash(gcloud run services describe*)"
       - "Bash(gcloud logging read*)"
@@ -100,4 +121,42 @@ claude_settings:
       - "Bash(yq*)"
       # Always allow searching
       - "WebSearch"
+    # Never allow these, even if the user would otherwise approve them. Package
+    # changes belong in the relevant Ansible role (e.g. roles/misc_packages), not
+    # ad-hoc shell commands. Read-only subcommands remain allowed above.
+    deny:
+      # Apt/apt-get (Linux) mutating subcommands.
+      - "Bash(apt install*)"
+      - "Bash(apt remove*)"
+      - "Bash(apt purge*)"
+      - "Bash(apt upgrade*)"
+      - "Bash(apt dist-upgrade*)"
+      - "Bash(apt autoremove*)"
+      - "Bash(apt update*)"
+      - "Bash(apt-get install*)"
+      - "Bash(apt-get remove*)"
+      - "Bash(apt-get purge*)"
+      - "Bash(apt-get upgrade*)"
+      - "Bash(apt-get dist-upgrade*)"
+      - "Bash(apt-get autoremove*)"
+      - "Bash(apt-get update*)"
+      # Mutating apt/apt-get commands nearly always require sudo, while the
+      # read-only ones allowed above never do — so deny sudo apt/apt-get outright.
+      - "Bash(sudo apt*)"
+      - "Bash(sudo apt-get*)"
+      # Homebrew (macOS) mutating subcommands.
+      - "Bash(brew install*)"
+      - "Bash(brew reinstall*)"
+      - "Bash(brew uninstall*)"
+      - "Bash(brew remove*)"
+      - "Bash(brew upgrade*)"
+      - "Bash(brew update*)"
+      - "Bash(brew tap*)"
+      - "Bash(brew untap*)"
+      - "Bash(brew pin*)"
+      - "Bash(brew unpin*)"
+      - "Bash(brew link*)"
+      - "Bash(brew unlink*)"
+      - "Bash(brew cleanup*)"
+      - "Bash(brew services*)"
     defaultMode: "plan"


### PR DESCRIPTION
## Summary
- Add `permissions.allow` entries for read-only `brew`/`apt`/`apt-get` subcommands (`list`, `info`, `search`, `show`, etc.) and a `permissions.deny` list blocking mutating ones (`install`, `remove`, `uninstall`, `upgrade`, `update`, `tap`, `services`, etc.), including a blanket deny on `sudo apt`/`sudo apt-get`.
- Extend the settings.json merge logic in `config.yml` to concatenate and dedupe `permissions.deny` the same way it already does for `permissions.allow`, so entries persist idempotently across playbook runs.
- Update `CLAUDE.md.j2`: drop the old "use brew/apt for package management" instructions and add a `## Package Management` section documenting the read-only-ok / mutating-blocked policy, since package changes should go through `roles/misc_packages` instead of ad-hoc commands.

## Test plan
- [x] `uvx ansible-lint roles/claude` passes with no violations
- [x] Parsed `vars/main.yml` to confirm expected allow/deny entries are present (e.g. `brew list` allowed, `brew install` denied, `apt search` allowed, `apt install` denied)