### PR TITLE
feat: deny ansible-playbook via claude permissions

### DIFF
--- a/roles/claude/vars/main.yml
+++ b/roles/claude/vars/main.yml
@@ -159,4 +159,8 @@ claude_settings:
       - "Bash(brew unlink*)"
       - "Bash(brew cleanup*)"
       - "Bash(brew services*)"
+      # Ansible — never run playbooks directly; they apply real changes to
+      # real machines and should only be run by the user.
+      - "Bash(ansible-playbook*)"
+      - "Bash(sudo ansible-playbook*)"
     defaultMode: "plan"


### PR DESCRIPTION
## Summary
- Adds `Bash(ansible-playbook*)` and `Bash(sudo ansible-playbook*)` to the Claude Code permissions `deny` list in `roles/claude/vars/main.yml`, so Claude can never invoke `ansible-playbook` directly (it applies real changes to real machines).
- Follows the same pattern established by the existing brew/apt mutating-command denials in the same file; no other files needed changes since the merge logic in `roles/claude/tasks/config.yml` picks up new deny entries generically.

## Test plan
- [x] `uvx ansible-lint roles/claude/vars/main.yml` passes with 0 failures/warnings