### PR TITLE
refactor: remove RTK rule prefix from commit skill

### DIFF
--- a/roles/claude/templates/skills/commit/SKILL.md.j2
+++ b/roles/claude/templates/skills/commit/SKILL.md.j2
@@ -27,7 +27,7 @@ Description of the changes, if provided: $ARGUMENTS
 6. **PR**: `gh pr view --json url --jq '.url' 2>/dev/null` — if none exists, `gh pr create`. Title matches the exact same format and verification rule as the commit subject in step 4. Body: `## Summary` (bullets), `## Test plan` (checklist). Base the summary on `git log main..HEAD`, not just the last commit.
 {% if claude_rtk_active %}
 
-**RTK rule**: run each command as a separate Bash call. Never `&&`-chain commands.
+Run each command as a separate Bash call. Never `&&`-chain commands.
 {% endif %}
 
 ## Final report


### PR DESCRIPTION
Remove the 'RTK rule' prefix from the commit skill documentation while keeping the templating and the underlying rule intact. The documentation now references the rule without mentioning RTK specifically.