### PR TITLE
feat: rewrite clone alias to use gh repo clone

### DIFF
--- a/roles/omz_zshrc/templates/zsh-custom/zsh-aliases.zsh.j2
+++ b/roles/omz_zshrc/templates/zsh-custom/zsh-aliases.zsh.j2
@@ -1,6 +1,12 @@
 ## When a new alias is added, it should be added to the "omz-zshrc/vars/main.yml" definition.
 ## In the case that it is a complex alias, the function can be defined within this .zsh file.
 
+function clone(){
+    # Normalize a supplied https://github.com/owner/repo URL down to "owner/repo" for gh.
+    repo="${1#https://github.com/}"
+    gh repo clone "$repo"
+}
+
 function docker_build_this(){
     # Build the Dockerfile in the current directory.
     docker build -t $(basename $(pwd)) .

--- a/roles/omz_zshrc/vars/main.yml
+++ b/roles/omz_zshrc/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 omz_zshrc_aliases:
   - alias: clone
-    command: git clone
-    description: git clone
+    command: clone
+    description: Clone a GitHub repo via 'gh repo clone'; accepts owner/repo or a github.com URL
 
   - alias: cleanup-branch
     command: cleanup-branch


### PR DESCRIPTION
## Summary
- Replace the plain `git clone` alias with a `clone` zsh function that always delegates to `gh repo clone`.
- The function strips a supplied `https://github.com/owner/repo` prefix down to `owner/repo` before calling `gh`; bare `owner/repo` input passes through unchanged. Extra args are intentionally not forwarded.
- Updated the alias description in `omz_zshrc` vars to reflect the new behavior (shown in the `zah` help output).

## Test plan
- [x] `uvx ansible-lint` passes
- [x] Manually simulated the parameter expansion in zsh for both a full GitHub URL and a bare `owner/repo` input, confirming both resolve to `gh repo clone owner/repo`