### PR TITLE
refactor: simplify git acp

### DIFF
--- a/roles/git/vars/main.yml
+++ b/roles/git/vars/main.yml
@@ -4,8 +4,8 @@
 git_gitconfig:
   - name: alias.acp
     value: >-
-      !b=$(git branch --show-current); case "$b" in
-      main|master) echo "On main/master. Aborting."; exit 1;;
+      !case "$(git symbolic-ref --short HEAD 2>/dev/null)" in
+      main|master) printf '\033[31m%s\033[0m\n' "On main/master. Aborting."; exit 1;;
       esac; git add . && git commit && git push
   - name: alias.ac
     value: "!git add .; git commit"

--- a/roles/git/vars/main.yml
+++ b/roles/git/vars/main.yml
@@ -1,14 +1,12 @@
 ---
 # vars file for git
 
-git_alias_acp: &git_alias_acp >-
-  !b=$(git branch --show-current); case "$b" in
-  main|master) echo "On main/master. Aborting."; exit 1;;
-  esac; git add . && git commit && git push
-
 git_gitconfig:
   - name: alias.acp
-    value: *git_alias_acp
+    value: >-
+      !b=$(git branch --show-current); case "$b" in
+      main|master) echo "On main/master. Aborting."; exit 1;;
+      esac; git add . && git commit && git push
   - name: alias.ac
     value: "!git add .; git commit"
   - name: alias.gafp

--- a/roles/git/vars/main.yml
+++ b/roles/git/vars/main.yml
@@ -1,12 +1,14 @@
 ---
 # vars file for git
+
+git_alias_acp: &git_alias_acp >-
+  !b=$(git branch --show-current); case "$b" in
+  main|master) echo "On main/master. Aborting."; exit 1;;
+  esac; git add . && git commit && git push
+
 git_gitconfig:
   - name: alias.acp
-    value: >-
-      {{ '!zsh ~/.oh-my-zsh/custom/scripts/git_acp.zsh'
-         if (git_acp_installed is defined
-             and not git_acp_installed.skipped | default(false))
-         else '!git add .; git commit; git push' }}
+    value: *git_alias_acp
   - name: alias.ac
     value: "!git add .; git commit"
   - name: alias.gafp

--- a/roles/omz_zshrc/tasks/main.yml
+++ b/roles/omz_zshrc/tasks/main.yml
@@ -70,9 +70,7 @@
   when: "omz_zshrc_goenv_folder.stat.exists and omz_zshrc_goenv_folder.stat.isdir"
 
 - name: Template git_acp.zsh
-  ansible.builtin.template:
-    src: zsh-custom/scripts/git_acp.zsh.j2
-    dest: "{{ homedir.stdout }}/.oh-my-zsh/custom/scripts/git_acp.zsh"
-    mode: "0644"
-  register: omz_zshrc_git_acp_installed
-  when: "omz_zshrc_omz_folder.stat.exists and omz_zshrc_omz_folder.stat.isdir"
+  # TODO: remove upon next update
+  ansible.builtin.file:
+    path: "{{ homedir.stdout }}/.oh-my-zsh/custom/scripts/git_acp.zsh"
+    state: absent

--- a/roles/omz_zshrc/templates/zsh-custom/scripts/git_acp.zsh.j2
+++ b/roles/omz_zshrc/templates/zsh-custom/scripts/git_acp.zsh.j2
@@ -1,8 +1,0 @@
-# Conducts "Git ACP", but only for non-canonically main branches
-current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
-  echo "Branch is 'main' or 'master'. Aborting further commands."
-  exit 1
-fi
-
-git add .; git commit; git push


### PR DESCRIPTION
## Summary

Replace the external `git_acp.zsh` helper script with a fully self-contained Git alias managed through the Git config Ansible variables.

The `git acp` alias now:

* Prevents accidental commits directly to `main` or `master`
* Provides a colored warning message when execution is blocked
* Runs the standard `git add`, `git commit`, and `git push` workflow directly from the Git alias
* Removes the dependency on a separate shell script

## Benefits

* Fewer moving parts to maintain
* Git behavior is now portable across environments and shells
* The alias is managed declaratively through Ansible alongside the rest of the Git configuration
* Reduces setup complexity for new machines/users

## Testing

Verified that:

* `git acp` aborts on `main` and `master`
* `git acp` continues normally on feature branches
* The generated `.gitconfig` entry executes correctly under standard shell environments
