### PR TITLE
refactor: invert role dep and override description

### DIFF
--- a/DAG.md
+++ b/DAG.md
@@ -5,11 +5,11 @@ graph TD
     facts
     gh_extensions -->|depends on| misc_packages
     git -->|depends on| facts
-    git -->|depends on| omz_zshrc
     misc_dotfiles -->|depends on| facts
     misc_dotfiles -->|depends on| misc_packages
     misc_packages
     omz_zshrc -->|depends on| facts
+    omz_zshrc -->|depends on| git
     omz_zshrc -->|depends on| misc_packages
     vim -->|depends on| facts
 

--- a/roles/git/meta/main.yml
+++ b/roles/git/meta/main.yml
@@ -1,6 +1,3 @@
 ---
 dependencies:
-  - role: omz_zshrc
-    # Only handle the omz_zshrc role on macOS systems
-    when: ansible_facts["os_family"] == "Darwin"
   - role: facts

--- a/roles/omz_zshrc/meta/main.yml
+++ b/roles/omz_zshrc/meta/main.yml
@@ -2,3 +2,4 @@
 dependencies:
   - role: facts
   - role: misc_packages
+  - role: git

--- a/roles/omz_zshrc/templates/zsh-custom/zsh-aliases.zsh.j2
+++ b/roles/omz_zshrc/templates/zsh-custom/zsh-aliases.zsh.j2
@@ -63,14 +63,17 @@ function zalias_title(){
 
 function zah(){
     zalias_title "Available Git Aliases: (usage: git <alias>)"
-    git config --list | grep alias | while read line
-      # todo: not dynamic.  This can be pulled from the git role, at which point this can be templated.
-        do
-            alias_name=${line#alias.}
-            alias_name=${alias_name%%=*}
-            alias_cmd=${line#*=}
-            printf '\033[37m  %-20s %s\033[0m\n' "$alias_name" "$alias_cmd"
-        done
+{% for git_item in (git_gitconfig | selectattr('name', 'match', '^alias\\.') | sort(attribute='name')) %}
+{% set git_alias_name = git_item.name | regex_replace('^alias\\.', '') %}
+{# acp uses inline bash; show a concise description instead of the full command. #}
+{# This is an exception, which we manage here rather than extending the role vars for git.#}
+{% if git_alias_name == 'acp' %}
+{% set git_alias_description = 'Add files, commit, and push' %}
+{% else %}
+{% set git_alias_description = git_item.value | string %}
+{% endif %}
+    printf '\033[37m  %-20s %s\033[0m\n' '{{ git_alias_name }}' '{{ git_alias_description | replace("'", "'\\''") }}'
+{% endfor %}
     echo ""
 
     zalias_title "Custom Zsh Aliases:"


### PR DESCRIPTION
# Summary 
Per https://github.com/karldreher/ansible-playbooks/pull/88/changes#diff-7e7eed57df8a224b4c053f4079701ed9e852b16d6031feaf5d82890981820912R67, there was a better way easily within reach - this and precedent fixes #89 #88 also makes the `git` role much more independent.