### PR TITLE
refactor: remove venv/pyenv tooling, retire brew_remove_casks

### DIFF
--- a/roles/misc_packages/tasks/brew_remove.yml
+++ b/roles/misc_packages/tasks/brew_remove.yml
@@ -1,5 +1,0 @@
----
-- name: Remove misc MacOS casks
-  community.general.homebrew_cask:
-    name: "{{ misc_packages_macos_brew_remove_casks }}"
-    state: absent

--- a/roles/misc_packages/tasks/main.yml
+++ b/roles/misc_packages/tasks/main.yml
@@ -5,11 +5,6 @@
   ansible.builtin.include_tasks: brew_packages.yml
   when: ansible_facts["os_family"] == "Darwin"
 
-- name: Remove macos homebrew packages
-  ansible.builtin.include_tasks: brew_remove.yml
-  when: ansible_facts["os_family"] == "Darwin"
-
-
 - name: Install script-based packages
   ansible.builtin.include_tasks: script-packages.yml
 

--- a/roles/misc_packages/vars/main.yml
+++ b/roles/misc_packages/vars/main.yml
@@ -19,7 +19,6 @@ misc_packages_macos_brew_packages:
   - jq
   - kubectx
   - parallel
-  - pyenv
   - ripgrep
   - rsync
   - tmux
@@ -31,6 +30,3 @@ misc_packages_macos_brew_packages:
 misc_packages_macos_brew_casks:
   - ghostty
   - rectangle
-
-misc_packages_macos_brew_remove_casks:
-  - raycast

--- a/roles/omz_zshrc/tasks/main.yml
+++ b/roles/omz_zshrc/tasks/main.yml
@@ -21,13 +21,6 @@
     - "misc_packages_brew_packages is defined"
     - "not misc_packages_brew_packages is failed"
 
-- name: Install venv plugin
-  ansible.builtin.git:
-    repo: https://github.com/glostis/venv-wrapper.git
-    dest: "{{ homedir.stdout }}/.oh-my-zsh/plugins/venv-wrapper"
-    version: 81af4239bc5bb99eaa98117b2988a29fdd5b7eb7
-  when: "omz_zshrc_omz_folder.stat.exists and omz_zshrc_omz_folder.stat.isdir"
-
 - name: Create notice files if they do not exist
   ansible.builtin.copy:
     dest: "{{ homedir.stdout }}/{{ item.file }}"

--- a/roles/omz_zshrc/templates/zsh-custom/zsh-aliases.zsh.j2
+++ b/roles/omz_zshrc/templates/zsh-custom/zsh-aliases.zsh.j2
@@ -9,7 +9,7 @@ function clone(){
 
 function docker_build_this(){
     # Build the Dockerfile in the current directory.
-    docker build -t $(basename $(pwd)) .
+    docker build -t ${PWD:t} .
 }
 
 function docker_run_this(){
@@ -25,26 +25,13 @@ function docker_run_this(){
     else
         PORT=""
     fi
-    docker run -it --rm $PORT $(basename $(pwd))
-}
-
-function ve(){
-    # Wrap the venv command and infer current working directory.
-    name=$(basename $(pwd))
-    # IF the directory does not have a .git directory, see if the one above does
-    if [[ ! -d .git ]]; then
-        if [[ -d ../.git ]]; then
-            # Use a combination of parent path and leaf
-            parent=$(basename $(dirname $(pwd)))
-            name=$parent--$name
-        fi
-    fi
-    venv $name
+    docker run -it --rm $PORT ${PWD:t}
 }
 
 function cleanup-branch(){
     branch_to_delete=$(git branch --show-current)
-    dest_branch=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')
+    dest_branch=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
+    dest_branch=${dest_branch#origin/}
     if [[ -z "$dest_branch" ]]; then
         echo "No default branch found."
         return 1

--- a/roles/omz_zshrc/vars/main.yml
+++ b/roles/omz_zshrc/vars/main.yml
@@ -44,18 +44,12 @@ omz_zshrc_aliases:
     command: git unstash
     description: git unstash
 
-  - alias: ve
-    command: ve
-    description: Wrap the venv command and infer current working directory for venv name.
-
 
 # To enable more omz plugins, add them here.
 omz_zshrc_omz_plugin_list:
   - git
-  - venv-wrapper
   - terraform
   - nvm
-  - pyenv
 
 # Notice files for profile experiments and reminders
 omz_zshrc_notices:


### PR DESCRIPTION
## Summary
- Removes the `ve()` zsh function and its `venv-wrapper`/`pyenv` oh-my-zsh plugins (git-clone task and `pyenv` brew package included), which are no longer wanted.
- Retires `misc_packages_macos_brew_remove_casks` entirely (variable, task file, and include) instead of leaving it as a dead, single-purpose mechanism.
- Swaps remaining forked `basename`/`dirname`/`sed` calls in `docker_build_this`, `docker_run_this`, and `cleanup-branch` for zsh builtin parameter expansion, continuing the printf-over-tput pattern from the prior PR.

## Test plan
- [x] `uvx ansible-lint` passes clean
- [x] Repo-wide grep confirms no dangling references to `venv-wrapper`, `pyenv`, `ve`, or `brew_remove_casks`