### PR TITLE
feat: add bun, uv, and vim to the upgrade task

### DIFF
--- a/roles/misc_packages/tasks/main.yml
+++ b/roles/misc_packages/tasks/main.yml
@@ -25,3 +25,7 @@
   ansible.builtin.import_tasks: apt_upgrade.yml
   when: ansible_facts["os_family"] == "Debian"
   tags: [upgrade, never]
+
+- name: Upgrade script-based packages
+  ansible.builtin.import_tasks: script-packages-upgrade.yml
+  tags: [upgrade, never]

--- a/roles/misc_packages/tasks/script-packages-upgrade.yml
+++ b/roles/misc_packages/tasks/script-packages-upgrade.yml
@@ -1,16 +1,8 @@
 ---
-- name: Upgrade bun (JavaScript runtime)  # noqa: command-instead-of-module
-  ansible.builtin.shell: |
-    set -o pipefail
-    curl -fsSL https://bun.sh/install | bash
-  args:
-    executable: /bin/bash
+- name: Upgrade bun (JavaScript runtime)
+  ansible.builtin.command: bun upgrade
   changed_when: true
 
-- name: Upgrade uv  # noqa: command-instead-of-module
-  ansible.builtin.shell: |
-    set -o pipefail
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-  args:
-    executable: /bin/bash
+- name: Upgrade uv
+  ansible.builtin.command: uv self update
   changed_when: true

--- a/roles/misc_packages/tasks/script-packages-upgrade.yml
+++ b/roles/misc_packages/tasks/script-packages-upgrade.yml
@@ -1,0 +1,16 @@
+---
+- name: Upgrade bun (JavaScript runtime)  # noqa: command-instead-of-module
+  ansible.builtin.shell: |
+    set -o pipefail
+    curl -fsSL https://bun.sh/install | bash
+  args:
+    executable: /bin/bash
+  changed_when: true
+
+- name: Upgrade uv  # noqa: command-instead-of-module
+  ansible.builtin.shell: |
+    set -o pipefail
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+  args:
+    executable: /bin/bash
+  changed_when: true

--- a/roles/vim/tasks/main.yml
+++ b/roles/vim/tasks/main.yml
@@ -29,3 +29,7 @@
     dest: "{{ homedir.stdout }}/.vim/pack/vim-conventional-commits/start/vim-conventional-commits"
     version: 7054464abde51172ecd088787077806b56398415
   when: vim_installed | default(false)
+
+- name: Upgrade vim
+  ansible.builtin.import_tasks: vim_upgrade.yml
+  tags: [upgrade, never]

--- a/roles/vim/tasks/vim_upgrade.yml
+++ b/roles/vim/tasks/vim_upgrade.yml
@@ -1,0 +1,14 @@
+---
+- name: Upgrade vim via Homebrew  # noqa: package-latest
+  community.general.homebrew:
+    name: vim
+    state: latest
+  when: ansible_facts["os_family"] == "Darwin"
+
+- name: Upgrade vim via apt  # noqa: package-latest
+  ansible.builtin.apt:
+    name: vim
+    state: latest
+    update_cache: true
+  become: true
+  when: ansible_facts["os_family"] == "Debian"


### PR DESCRIPTION
## Summary
- bun and uv are installed via curl scripts in `roles/misc_packages/tasks/script-packages.yml` but had no upgrade path, so re-running the playbook with `--tags upgrade` never updated them.
- vim had the same gap. Both now follow the existing `tags: [upgrade, never]` pattern already used for brew/apt packages, `gh` extensions, and `rtk`.

## Test plan
- [x] `uvx ansible-lint` passes with 0 failures/warnings
- [ ] `ansible-playbook main.yml --tags upgrade --check --diff` against `inventory-local`