### PR TITLE
feat: add omz-vimtips plugin to omz_zshrc

### DIFF
--- a/roles/omz_zshrc/tasks/main.yml
+++ b/roles/omz_zshrc/tasks/main.yml
@@ -21,6 +21,13 @@
     - "misc_packages_brew_packages is defined"
     - "not misc_packages_brew_packages is failed"
 
+- name: Install omz-vimtips plugin
+  ansible.builtin.git:
+    repo: https://github.com/karldreher/omz-vimtips.git
+    dest: "{{ homedir.stdout }}/.oh-my-zsh/custom/plugins/omz-vimtips"
+    version: c7cde5c19b78cccb629265915809c831f70209de
+  when: "omz_zshrc_omz_folder.stat.exists and omz_zshrc_omz_folder.stat.isdir"
+
 - name: Create notice files if they do not exist
   ansible.builtin.copy:
     dest: "{{ homedir.stdout }}/{{ item.file }}"

--- a/roles/omz_zshrc/vars/main.yml
+++ b/roles/omz_zshrc/vars/main.yml
@@ -50,6 +50,7 @@ omz_zshrc_omz_plugin_list:
   - git
   - terraform
   - nvm
+  - omz-vimtips  # custom plugin, cloned by tasks/main.yml
 
 # Notice files for profile experiments and reminders
 omz_zshrc_notices:


### PR DESCRIPTION
## Summary
- Clone `karldreher/omz-vimtips` into the Oh My Zsh custom plugins directory, pinned to a specific commit, following the same `ansible.builtin.git` pattern used for `vim-conventional-commits` in the `vim` role.
- Enable it via `omz_zshrc_omz_plugin_list`, which renders into `.zshrc`'s `plugins=(...)` array.

## Test plan
- [x] `uvx ansible-lint` passes clean
- [ ] Apply the playbook against a host with Oh My Zsh installed and confirm `omz-vimtips` loads and prints a tip on new shells