### PR TITLE
feat: adapt omz_zshrc role to run on debian

### DIFF
--- a/DAG.md
+++ b/DAG.md
@@ -7,7 +7,7 @@ graph TD
     git -->|depends on| facts
     misc_dotfiles -->|depends on| facts
     misc_dotfiles -->|depends on| misc_packages
-    misc_packages
+    misc_packages -->|depends on| facts
     omz_zshrc -->|depends on| facts
     omz_zshrc -->|depends on| git
     omz_zshrc -->|depends on| misc_packages

--- a/main.yml
+++ b/main.yml
@@ -6,7 +6,6 @@
     - role: misc_packages
     - role: gh_extensions
     - role: omz_zshrc
-      when: ansible_facts["os_family"] == "Darwin"
     - role: misc_dotfiles
     - role: vim
     - role: claude

--- a/roles/misc_dotfiles/templates/alacritty/alacritty.toml.j2
+++ b/roles/misc_dotfiles/templates/alacritty/alacritty.toml.j2
@@ -1,3 +1,5 @@
+[window]
+dimensions = { columns = 120, lines = 40 }
 
 [[keyboard.bindings]]
 key = "Return"

--- a/roles/misc_packages/meta/main.yml
+++ b/roles/misc_packages/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: facts

--- a/roles/misc_packages/tasks/main.yml
+++ b/roles/misc_packages/tasks/main.yml
@@ -16,12 +16,20 @@
   ansible.builtin.include_tasks: apt_packages.yml
   when: ansible_facts["os_family"] == "Debian"
 
+- name: Check that zsh binary exists
+  ansible.builtin.stat:
+    path: /usr/bin/zsh
+  register: misc_packages_zsh_binary
+  when: ansible_facts["os_family"] == "Debian"
+
 - name: Set zsh as default login shell
   ansible.builtin.user:
     name: "{{ ansible_user_id }}"
     shell: /usr/bin/zsh
   become: true
-  when: ansible_facts["os_family"] == "Debian"
+  when:
+    - ansible_facts["os_family"] == "Debian"
+    - misc_packages_zsh_binary.stat.exists
 
 - name: Upgrade macOS homebrew packages
   ansible.builtin.import_tasks: brew_upgrade.yml

--- a/roles/misc_packages/tasks/main.yml
+++ b/roles/misc_packages/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Set zsh as default login shell
   ansible.builtin.user:
-    name: ansible_facts["user_id"]
+    name: "{{ ansible_facts['user_id'] }}"
     shell: /usr/bin/zsh
   become: true
   when:

--- a/roles/misc_packages/tasks/main.yml
+++ b/roles/misc_packages/tasks/main.yml
@@ -16,6 +16,13 @@
   ansible.builtin.include_tasks: apt_packages.yml
   when: ansible_facts["os_family"] == "Debian"
 
+- name: Set zsh as default login shell
+  ansible.builtin.user:
+    name: "{{ ansible_user_id }}"
+    shell: /usr/bin/zsh
+  become: true
+  when: ansible_facts["os_family"] == "Debian"
+
 - name: Upgrade macOS homebrew packages
   ansible.builtin.import_tasks: brew_upgrade.yml
   when: ansible_facts["os_family"] == "Darwin"

--- a/roles/misc_packages/tasks/main.yml
+++ b/roles/misc_packages/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Set zsh as default login shell
   ansible.builtin.user:
-    name: "{{ ansible_user_id }}"
+    name: ansible_facts["user_id"]
     shell: /usr/bin/zsh
   become: true
   when:

--- a/roles/omz_zshrc/templates/zshrc.zsh.j2
+++ b/roles/omz_zshrc/templates/zshrc.zsh.j2
@@ -28,9 +28,11 @@ plugins=( {{ omz_zshrc_omz_plugin_list | join(" ") }} )
 zstyle ':omz:plugins:nvm' autoload yes
 
 # Autocompletions - Must precede sourcing omz
+{% if ansible_facts['os_family'] == 'Darwin' %}
 ## Homebrew
 export HOMEBREW_NO_AUTO_UPDATE=1
 FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
+{% endif %}
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
## Summary
- Set zsh as the default login shell on Debian (installed via apt already, just never activated)
- Declare `misc_packages`'s implicit dependency on the `facts` role explicitly in `meta/main.yml`
- Guard the Homebrew-only FPATH line in the zshrc template behind a Darwin check
- Remove the Darwin-only gate so `omz_zshrc` runs on all hosts, plus regenerate `DAG.md` to reflect the new dependency edge

## Test plan
- [x] `uvx ansible-lint` passes with 0 failures/warnings
- [x] `ansible-playbook main.yml --syntax-check` passes
- [ ] Run the playbook end-to-end on a Debian host to confirm zsh becomes the login shell and `.zshrc` renders without Homebrew references