### PR TITLE
feat: install goenv via brew with an upgrade path

### DIFF
--- a/roles/misc_packages/vars/main.yml
+++ b/roles/misc_packages/vars/main.yml
@@ -15,6 +15,7 @@ misc_packages_macos_brew_taps:
 misc_packages_macos_brew_packages:
   - diceware
   - gh
+  - goenv
   - httpie
   - jq
   - kubectx

--- a/roles/omz_zshrc/tasks/main.yml
+++ b/roles/omz_zshrc/tasks/main.yml
@@ -6,10 +6,11 @@
     path: "{{ homedir.stdout }}/.oh-my-zsh"
   register: omz_zshrc_omz_folder
 
-- name: Check that goenv folder exists
-  ansible.builtin.stat:
-    path: "{{ homedir.stdout }}/.goenv"
-  register: omz_zshrc_goenv_folder
+- name: Check if goenv is installed
+  ansible.builtin.command: which goenv
+  register: omz_zshrc_goenv_binary
+  failed_when: false
+  changed_when: false
 
 - name: Tfswitch enabled
   # TODO: Refactor this more elegantly later, but this is more of a
@@ -67,7 +68,7 @@
     src: zsh-custom/zsh-goenv.zsh.j2
     dest: "{{ homedir.stdout }}/.oh-my-zsh/custom/zsh-goenv.zsh"
     mode: "0644"
-  when: "omz_zshrc_goenv_folder.stat.exists and omz_zshrc_goenv_folder.stat.isdir"
+  when: "omz_zshrc_goenv_binary.rc == 0"
 
 - name: Template git_acp.zsh
   # TODO: remove upon next update

--- a/roles/omz_zshrc/templates/zsh-custom/zsh-goenv.zsh.j2
+++ b/roles/omz_zshrc/templates/zsh-custom/zsh-goenv.zsh.j2
@@ -1,6 +1,3 @@
 export GOENV_ROOT="$HOME/.goenv"
 export PATH="$GOENV_ROOT/bin:$PATH"
 eval "$(goenv init -)"
-
-export PATH="$GOROOT/bin:$PATH"
-export PATH="$PATH:$GOPATH/bin"


### PR DESCRIPTION
## Summary
- Adds `goenv` to the `misc_packages` brew package list, giving it both an install and an upgrade path (`--tags upgrade`) like other brew-managed tools.
- Updates `omz_zshrc` to detect the `goenv` binary via `which goenv` instead of checking for the legacy `~/.goenv` folder, since brew's v3 formula never creates that directory.
- Trims `zsh-goenv.zsh.j2` to goenv v3's official `.zshrc` snippet, removing manual `GOROOT`/`GOPATH` `PATH` exports that v3 already handles via shims.

## Test plan
- [x] `uvx ansible-lint` passes with 0 failures, 0 warnings
- [ ] Run the playbook against a macOS host and confirm `goenv` installs/upgrades via brew and `.oh-my-zsh/custom/zsh-goenv.zsh` is templated correctly