### PR TITLE
feat: restore marketplace skills install and add oblique-skill

### DIFF
--- a/roles/claude/tasks/main.yml
+++ b/roles/claude/tasks/main.yml
@@ -22,6 +22,9 @@
 - name: Install claude skills
   ansible.builtin.include_tasks: skills.yml
 
+- name: Install and remove marketplace skills
+  ansible.builtin.include_tasks: marketplace_skills.yml
+
 - name: Upgrade rtk
   ansible.builtin.import_tasks: rtk_upgrade.yml
   tags: [upgrade, never]

--- a/roles/claude/tasks/marketplace_skills.yml
+++ b/roles/claude/tasks/marketplace_skills.yml
@@ -1,0 +1,18 @@
+---
+- name: Install marketplace skills
+  ansible.builtin.command: >-
+    bunx skills add -g {{ item.repo }}{{ '#' + item.ref if item.ref is defined else '' }}
+    --skill {{ item.skill }} --yes
+  args:
+    creates: "{{ homedir.stdout }}/.claude/skills/{{ item.skill }}/SKILL.md"
+  loop: "{{ claude_marketplace_skills }}"
+  loop_control:
+    label: "{{ item.skill }}"
+
+- name: Remove marketplace skills
+  ansible.builtin.command: bunx skills remove -g {{ item.repo }} --skill {{ item.skill }} --yes
+  args:
+    removes: "{{ homedir.stdout }}/.claude/skills/{{ item.skill }}/SKILL.md"
+  loop: "{{ claude_marketplace_skills_remove }}"
+  loop_control:
+    label: "{{ item.skill }}"

--- a/roles/claude/vars/main.yml
+++ b/roles/claude/vars/main.yml
@@ -2,6 +2,16 @@
 # https://code.claude.com/docs/en/settings.md
 # https://code.claude.com/docs/en/permissions.md
 
+# Skills from https://skills.sh/
+# Each entry: { repo: "<owner/repo>", skill: "<skill-name>", ref: "<optional branch/tag/sha>" }
+claude_marketplace_skills:
+  - repo: "karldreher/oblique-skill"
+    skill: "oblique"
+    ref: "e8d2d2958ae48578ba0dd3dc4824708390183920"
+
+# Skills to uninstall — same format as claude_marketplace_skills
+claude_marketplace_skills_remove: []
+
 claude_settings:
   attribution:
     commit: ""

--- a/roles/claude/vars/main.yml
+++ b/roles/claude/vars/main.yml
@@ -3,11 +3,10 @@
 # https://code.claude.com/docs/en/permissions.md
 
 # Skills from https://skills.sh/
-# Each entry: { repo: "<owner/repo>", skill: "<skill-name>", ref: "<optional branch/tag/sha>" }
+# Each entry: { repo: "<owner/repo>", skill: "<skill-name>", ref: "<optional branch/tag>" }
 claude_marketplace_skills:
   - repo: "karldreher/oblique-skill"
     skill: "oblique"
-    ref: "e8d2d2958ae48578ba0dd3dc4824708390183920"
 
 # Skills to uninstall — same format as claude_marketplace_skills
 claude_marketplace_skills_remove: []


### PR DESCRIPTION
## Summary
- Restores `roles/claude/tasks/marketplace_skills.yml`, a `bunx skills add/remove`-based mechanism for installing third-party Claude Code skills, which had been removed in an earlier cleanup.
- Wires it into `roles/claude/tasks/main.yml` right after the existing first-party skills install step.
- Adds `claude_marketplace_skills`/`claude_marketplace_skills_remove` vars, configuring the `oblique` skill from `karldreher/oblique-skill` (tracking its `main` branch), plus an optional `ref` attribute on each entry for pinning to a branch or tag when needed (the CLI clones via `git clone --branch <ref>`, so raw commit SHAs aren't supported).

## Test plan
- [x] `uvx ansible-lint` passes with 0 failures, 0 warnings